### PR TITLE
Update Gradle CI workflow for manual release inputs

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,5 +1,6 @@
 # This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
 
 name: Java CI with Gradle
 
@@ -12,31 +13,45 @@ on:
     branches: [ master ]
     paths-ignore:
       - '*.md'
-
+  workflow_dispatch:        # 👈 Adds manual "Run workflow" button
+    inputs:
+      release_tag:
+        description: "Release tag (optional)"
+        required: false
+        default: "latest-1.21.4"
+      release_title:
+        description: "Release title (optional)"
+        required: false
+        default: "1.21.4 Build"
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up JDK 21
-      uses: actions/setup-java@v4.7.0
-      with:
-        java-version: 21
-        distribution: 'zulu'
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build
-    - name: Remove *-dev.jar
-      run: rm ./build/libs/*-dev.jar || true
-    - uses: "marvinpinto/action-automatic-releases@latest"
-      with:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4.7.0
+        with:
+          java-version: 21
+          distribution: 'zulu'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build
+
+      - name: Remove *-dev.jar
+        run: rm ./build/libs/*-dev.jar || true
+
+      # 🔥 Auto or Manual Release
+      - uses: marvinpinto/action-automatic-releases@latest
+        with:
           repo_token: "${{ secrets.GITHUB_TOKEN }}"
-          automatic_release_tag: "latest-1.21.4"
+          automatic_release_tag: ${{ github.event.inputs.release_tag || 'latest-1.21.4' }}
           prerelease: false
-          title: "1.21.4 Build"
+          title: ${{ github.event.inputs.release_title || '1.21.4 Build' }}
           files: |
             ./build/libs/*.jar
-


### PR DESCRIPTION
This PR allows auto CI/CD releases instead of manually having to build from repo.